### PR TITLE
Add VS Code Word Count extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ typings/
 
 node_modules/
 models/
+
+# VS Code extension build output
+out/
+*.vsix

--- a/vscode-word-count/.vscodeignore
+++ b/vscode-word-count/.vscodeignore
@@ -1,0 +1,6 @@
+.vscode/**
+src/**
+node_modules/**
+tsconfig.json
+**/*.ts
+**/*.map

--- a/vscode-word-count/README.md
+++ b/vscode-word-count/README.md
@@ -1,0 +1,31 @@
+# Word Count — VS Code Extension
+
+A minimal word count extension that shows a live count in the status bar.
+
+## Features
+
+- **Status bar word count** – displays total words in the current document (bottom-left).
+- **Selection-aware** – when you select text, the count switches to show only the selected words.
+- **Markdown-friendly** – strips front-matter, links, images, HTML tags, and heading markers so the count reflects actual prose.
+- **Configurable languages** – enabled for Markdown, Plain Text, LaTeX, HTML, and reStructuredText by default. Add or remove language IDs via the `wordCount.enabledLanguages` setting.
+
+## Install (local / dev)
+
+```bash
+cd vscode-word-count
+npm install
+npm run compile
+```
+
+Then press **F5** in VS Code to launch an Extension Development Host, or package with `vsce`:
+
+```bash
+npx @vscode/vsce package
+code --install-extension word-count-0.1.0.vsix
+```
+
+## Configuration
+
+| Setting                        | Default                                                        | Description                           |
+| ------------------------------ | -------------------------------------------------------------- | ------------------------------------- |
+| `wordCount.enabledLanguages`   | `["markdown","plaintext","latex","html","restructuredtext"]`   | Language IDs that activate the count. |

--- a/vscode-word-count/package-lock.json
+++ b/vscode-word-count/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "word-count",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "word-count",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.80.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "vscode": "^1.80.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
+      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.108.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.108.1.tgz",
+      "integrity": "sha512-DerV0BbSzt87TbrqmZ7lRDIYaMiqvP8tmJTzW2p49ZBVtGUnGAu2RGQd1Wv4XMzEVUpaHbsemVM5nfuQJj7H6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-word-count/package.json
+++ b/vscode-word-count/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "word-count",
+  "displayName": "Word Count",
+  "description": "Shows word count in the status bar. Counts words in the full document or just the selected text.",
+  "version": "0.1.0",
+  "publisher": "chrisshaw",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onLanguage:markdown",
+    "onLanguage:plaintext",
+    "onLanguage:latex",
+    "onLanguage:html",
+    "onLanguage:restructuredtext"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Word Count",
+      "properties": {
+        "wordCount.enabledLanguages": {
+          "type": "array",
+          "default": [
+            "markdown",
+            "plaintext",
+            "latex",
+            "html",
+            "restructuredtext"
+          ],
+          "description": "Language IDs for which the word count status bar item is shown."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.80.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/vscode-word-count/src/extension.ts
+++ b/vscode-word-count/src/extension.ts
@@ -1,0 +1,82 @@
+import * as vscode from "vscode";
+
+let statusBarItem: vscode.StatusBarItem;
+
+export function activate(context: vscode.ExtensionContext) {
+  statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    100
+  );
+  statusBarItem.tooltip = "Document Word Count";
+  context.subscriptions.push(statusBarItem);
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(updateWordCount),
+    vscode.window.onDidChangeTextEditorSelection(updateWordCount),
+    vscode.workspace.onDidChangeTextDocument(updateWordCount)
+  );
+
+  updateWordCount();
+}
+
+function updateWordCount() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    statusBarItem.hide();
+    return;
+  }
+
+  const enabledLanguages = vscode.workspace
+    .getConfiguration("wordCount")
+    .get<string[]>("enabledLanguages", [
+      "markdown",
+      "plaintext",
+      "latex",
+      "html",
+      "restructuredtext",
+    ]);
+
+  if (!enabledLanguages.includes(editor.document.languageId)) {
+    statusBarItem.hide();
+    return;
+  }
+
+  const selection = editor.selection;
+  const hasSelection = !selection.isEmpty;
+
+  const text = hasSelection
+    ? editor.document.getText(selection)
+    : editor.document.getText();
+
+  const words = countWords(text);
+  const label = hasSelection ? `$(pencil) ${words} words selected` : `$(book) ${words} words`;
+
+  statusBarItem.text = label;
+  statusBarItem.show();
+}
+
+function countWords(text: string): number {
+  // Strip common markdown/markup syntax so it doesn't inflate the count.
+  const cleaned = text
+    // YAML front-matter
+    .replace(/^---[\s\S]*?---/m, "")
+    // HTML tags
+    .replace(/<[^>]+>/g, "")
+    // Markdown images ![alt](url)
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    // Markdown links – keep the link text: [text](url) → text
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    // Markdown heading markers, blockquote markers, horizontal rules
+    .replace(/^[#>*\-=`~]+\s?/gm, "")
+    // Inline code / code fences
+    .replace(/`{1,3}[^`]*`{1,3}/g, "")
+    // Reference-style link definitions [id]: url
+    .replace(/^\[[^\]]*\]:\s.*$/gm, "");
+
+  const matches = cleaned.match(/\S+/g);
+  return matches ? matches.length : 0;
+}
+
+export function deactivate() {
+  // nothing to clean up – disposables are handled by the context
+}

--- a/vscode-word-count/tsconfig.json
+++ b/vscode-word-count/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
This PR introduces a new VS Code extension that displays a live word count in the status bar. The extension is selection-aware and includes smart text processing to strip markup syntax for accurate prose counting.

## Key Changes
- **New extension structure**: Added `vscode-word-count/` directory with complete extension scaffolding (TypeScript, package.json, tsconfig.json)
- **Core functionality** (`src/extension.ts`):
  - Status bar item that displays word count on the left side
  - Real-time updates on text changes, selection changes, and editor switches
  - Selection-aware counting: shows selected word count when text is highlighted
  - Smart text cleaning that strips YAML front-matter, HTML tags, Markdown syntax (links, images, headings), code blocks, and reference-style link definitions
- **Configuration**: Added `wordCount.enabledLanguages` setting (default: Markdown, Plain Text, LaTeX, HTML, reStructuredText)
- **Build setup**: TypeScript compilation with strict mode enabled, npm scripts for compilation and watching
- **Documentation**: Added comprehensive README with features, installation, and configuration details
- **Packaging**: Added `.vscodeignore` to exclude source files from the packaged extension
- **Updated .gitignore**: Added VS Code extension build output (`out/`, `*.vsix`)

## Implementation Details
- The word counter uses regex-based text cleaning to handle common markup patterns before counting whitespace-separated tokens
- Event listeners are registered for active editor changes, text selection changes, and document modifications to keep the count synchronized
- The extension respects user configuration for enabled languages and gracefully hides the status bar item when the current document language is not enabled

https://claude.ai/code/session_014DWwTn3ctcRt2wNTifj1Hh