### PR TITLE
feat: add AI-powered tool generator for Zwibbler whiteboards

### DIFF
--- a/zwibbler-tool-generator/README.md
+++ b/zwibbler-tool-generator/README.md
@@ -1,0 +1,101 @@
+# Zwibbler Tool Generator
+
+An AI-powered tool generator for [Zwibbler](https://zwibbler.com) whiteboards. Users describe academic tools in natural language — calculator, periodic table, coordinate plane, unit converter, etc. — and a Claude-backed agent generates interactive HTML widgets that drop directly onto the whiteboard canvas.
+
+## How it works
+
+```
+User prompt  →  Claude API  →  JSON { html, css, js }  →  Sandbox validation  →  Zwibbler.component()  →  Canvas
+     ↑                                                           ↑
+ "I need a                                                Static analysis
+  fraction                                               blocks dangerous
+  visualizer"                                             patterns (fetch,
+                                                          eval, navigation,
+                                                          external URLs...)
+```
+
+1. **User describes a tool** in natural language via the generator dialog
+2. **Claude generates** a self-contained widget (HTML + scoped CSS + vanilla JS) following strict constraints in the system prompt
+3. **The sandbox validates** the output with static analysis — blocking network requests, dynamic code execution, navigation, storage access, external resources, and inline event handlers
+4. **User previews** the widget in a sandboxed iframe before accepting
+5. **The widget is registered** as a `Zwibbler.component()` and placed on the canvas as a movable, resizable HTML node
+6. **The tool appears in the sidebar** so the user can stamp additional copies
+
+## Architecture
+
+| File | Purpose |
+|---|---|
+| `index.html` | Main page — Zwibbler canvas + toolbar + generator dialog |
+| `style.css` | All styling |
+| `tool-generator.js` | Claude API integration — system prompt + request/response handling |
+| `sandbox.js` | Static analysis validator + sandboxed iframe preview |
+| `app.js` | Glue — Zwibbler controller, dialog lifecycle, component registration |
+| `server.js` | Optional Node.js dev server with API proxy (keeps key server-side) |
+
+## Zwibbler integration points
+
+The system uses three key Zwibbler APIs:
+
+- **`Zwibbler.component(name, { template, controller })`** — registers each generated widget as a reusable component with its own HTML template and JS controller
+- **`ctx.createHTMLNode(componentName, properties)`** — places the component on the canvas as a movable/resizable node
+- **`ctx.begin()` / `ctx.commit()`** — wraps placement in a transaction for proper undo support
+
+Generated widgets become first-class Zwibbler objects: users can drag, resize, and layer them alongside pen strokes, shapes, and text.
+
+## Safety model
+
+The generator uses defense in depth:
+
+1. **Constrained system prompt** — Claude is instructed to produce only academic widgets with no network access, no external resources, no eval, no DOM escape, etc.
+2. **Static analysis** (`sandbox.js`) — regex-based validator rejects code containing ~30 dangerous patterns (fetch, eval, innerHTML=, createElement('script'), external URLs, localStorage, etc.)
+3. **Sandboxed preview** — the widget renders in an `<iframe sandbox="allow-scripts">` (no same-origin access) before the user accepts it
+4. **Scoped execution** — the JS runs inside a `Zwibbler.component` controller, scoped to its own DOM element. Errors are caught and displayed inline rather than crashing the whiteboard.
+5. **Automatic retry** — if the first generation fails validation, the system retries once before reporting the failure
+
+## Setup
+
+### Prerequisites
+
+- A [Zwibbler license](https://zwibbler.com) — place `zwibbler.js` in this directory
+- An [Anthropic API key](https://console.anthropic.com/)
+- Node.js 18+ (for the dev server; optional if you serve files another way)
+
+### Running with the dev server (recommended)
+
+```bash
+cd zwibbler-tool-generator
+ANTHROPIC_API_KEY=sk-ant-... node server.js
+```
+
+Open `http://localhost:3000`. The API key stays server-side.
+
+### Running without the dev server
+
+Serve the files with any static HTTP server. On first use, the app will prompt for your API key in the browser. The key is stored only in `sessionStorage` (cleared when the tab closes) and sent directly to the Anthropic API with `anthropic-dangerous-direct-browser-access`.
+
+## Example prompts
+
+- "A basic calculator with +, -, ×, ÷ and a clear button"
+- "An interactive periodic table where clicking an element shows its details"
+- "A unit converter for length, mass, and temperature"
+- "A coordinate plane where you can plot points by clicking"
+- "A fraction visualizer with pie chart representation"
+- "A multiplication table from 1-12 with highlighting"
+- "A simple protractor that can measure angles"
+- "A stopwatch with lap times for science experiments"
+- "A quadratic equation solver that shows the discriminant and roots"
+- "Graph paper with adjustable grid spacing"
+
+## Design decisions
+
+**Why generate HTML widgets rather than curate a fixed library?**
+The combinatorial space of useful academic tools is enormous — every subject, every grade level, every specific lesson. A fixed library can never be complete. Generation lets users get exactly the tool they need in seconds, including niche tools (e.g., "a Roman numeral converter" or "a color wheel with RGB/HSL values") that would never make a curated list.
+
+**Why not use existing open-source widget libraries?**
+For a production system, you'd want a hybrid: a curated set of high-quality pre-built components for the most common needs (calculator, timer, graph paper), supplemented by the generator for everything else. This prototype focuses on the generation path to prove the concept.
+
+**Why static analysis instead of a full JS sandbox (e.g., SES/Compartment)?**
+Static analysis is lightweight, fast, and catches the patterns that matter most for this threat model (data exfiltration, code injection, external resource loading). A full JS sandbox like SES would be more robust but adds complexity and may interfere with Zwibbler's framework. For production, adding SES or running widgets in isolated iframes that communicate via postMessage would be a worthwhile hardening step.
+
+**Why `new Function()` in the component controller?**
+The generated JS needs access to the component's DOM element. Zwibbler's controller pattern provides a `scope` object. We bridge these by wrapping the generated JS in a `new Function("scope", "el", generatedCode)` call. Yes, this is a form of eval — but it runs code that has already passed static analysis, and it runs within Zwibbler's component lifecycle, not at the global scope. The alternative (injecting the JS as a `<script>` tag) would be harder to scope and manage.

--- a/zwibbler-tool-generator/app.js
+++ b/zwibbler-tool-generator/app.js
@@ -1,0 +1,240 @@
+/**
+ * app.js
+ *
+ * Wires together the Zwibbler canvas, the AI tool generator, and the sandbox.
+ * This is the main application entry point.
+ */
+
+(() => {
+  "use strict";
+
+  // ── State ────────────────────────────────────────────────
+
+  let zwibblerCtx = null;           // ZwibblerContext, set by initApp
+  let generatedToolCounter = 0;     // unique suffix for component names
+  let pendingTool = null;           // tool waiting to be accepted from preview
+  let apiKey = "";                  // Anthropic API key (empty = use server proxy)
+  let useServerProxy = false;       // true when server has the key
+
+  // Persisted list of generated tools available in the sidebar.
+  // Each entry: { componentName, label, description, width, height }
+  const generatedToolsList = [];
+
+  // ── API Key Management ───────────────────────────────────
+  //
+  // On startup, we probe the server proxy. If it's configured with a key,
+  // we skip asking the user for one. Otherwise, fall back to client-side key.
+
+  async function detectServerProxy() {
+    try {
+      const res = await fetch("/api/generate", { method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: "__ping__", size: "small" }),
+      });
+      // If we get a 502 or the server says no key, it's not configured
+      if (res.status === 500) {
+        const body = await res.json();
+        if (body.error && body.error.includes("no ANTHROPIC_API_KEY")) return false;
+      }
+      // Any other response (including 4xx from Anthropic) means the proxy is working
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  function getApiKey() {
+    if (useServerProxy) return ""; // empty string signals proxy mode to ToolGenerator
+    if (apiKey) return apiKey;
+    const stored = sessionStorage.getItem("ztg_api_key");
+    if (stored) { apiKey = stored; return apiKey; }
+    const entered = prompt(
+      "Enter your Anthropic API key.\n\n" +
+      "This is stored only in your browser session and sent directly to the Anthropic API.\n" +
+      "Alternatively, run the server with ANTHROPIC_API_KEY set to avoid this prompt."
+    );
+    if (!entered) throw new Error("API key is required to generate tools.");
+    apiKey = entered.trim();
+    sessionStorage.setItem("ztg_api_key", apiKey);
+    return apiKey;
+  }
+
+  // ── Zwibbler Controller ──────────────────────────────────
+  //
+  // This function is referenced by z-controller="initApp" in the HTML.
+  // Zwibbler calls it with the ZwibblerContext as the scope.
+
+  window.initApp = function (ctx) {
+    zwibblerCtx = ctx;
+
+    // Detect if the server proxy has an API key configured
+    detectServerProxy().then(hasProxy => { useServerProxy = hasProxy; });
+
+    // Expose the generated tools list to the Zwibbler framework for z-for binding
+    ctx.generatedTools = generatedToolsList;
+
+    // Open the generator dialog
+    ctx.openGenerator = function () {
+      document.getElementById("generator-overlay").classList.remove("hidden");
+      document.getElementById("tool-prompt").focus();
+    };
+
+    // Place a previously generated tool onto the canvas
+    ctx.placeGeneratedTool = function (tool) {
+      placeToolOnCanvas(tool);
+    };
+
+    // Simple zoom helpers
+    ctx.zoomIn = function () { ctx.setZoom(ctx.getZoom() * 1.2); };
+    ctx.zoomOut = function () { ctx.setZoom(ctx.getZoom() / 1.2); };
+  };
+
+  // ── Dialog Helpers (called from HTML onclick) ────────────
+
+  window.closeGenerator = function () {
+    document.getElementById("generator-overlay").classList.add("hidden");
+    document.getElementById("generator-status").classList.add("hidden");
+    document.getElementById("generator-preview").classList.add("hidden");
+    pendingTool = null;
+  };
+
+  window.setPromptHint = function (chip) {
+    const input = document.getElementById("tool-prompt");
+    input.value = chip.textContent;
+    input.focus();
+  };
+
+  window.doGenerate = async function () {
+    const promptText = document.getElementById("tool-prompt").value.trim();
+    if (!promptText) return;
+
+    let key;
+    try { key = getApiKey(); } catch { return; }
+
+    const sizeKey = document.getElementById("tool-size").value;
+    const statusEl = document.getElementById("generator-status");
+    const statusText = document.getElementById("status-text");
+    const previewEl = document.getElementById("generator-preview");
+    const generateBtn = document.getElementById("btn-do-generate");
+
+    // Show spinner, hide previous preview
+    statusEl.classList.remove("hidden");
+    previewEl.classList.add("hidden");
+    generateBtn.disabled = true;
+    statusText.textContent = "Generating your tool...";
+
+    try {
+      const tool = await ToolGenerator.generate(key, promptText, sizeKey);
+
+      // Validate through sandbox
+      const result = Sandbox.validate(tool);
+      if (!result.valid) {
+        statusText.textContent = "Generated code failed safety checks. Retrying...";
+        // One automatic retry — the model sometimes slips on a single constraint
+        const tool2 = await ToolGenerator.generate(key, promptText, sizeKey);
+        const result2 = Sandbox.validate(tool2);
+        if (!result2.valid) {
+          throw new Error(
+            "Generated tool failed safety validation:\n" +
+            result2.reasons.join("\n")
+          );
+        }
+        pendingTool = tool2;
+      } else {
+        pendingTool = tool;
+      }
+
+      // Show preview
+      statusEl.classList.add("hidden");
+      previewEl.classList.remove("hidden");
+      Sandbox.renderPreview(
+        document.getElementById("preview-frame"),
+        pendingTool
+      );
+
+    } catch (err) {
+      statusText.textContent = `Error: ${err.message}`;
+      console.error("Tool generation failed:", err);
+    } finally {
+      generateBtn.disabled = false;
+    }
+  };
+
+  window.regenerateTool = function () {
+    window.doGenerate();
+  };
+
+  window.acceptTool = function () {
+    if (!pendingTool || !zwibblerCtx) return;
+    const registered = registerZwibblerComponent(pendingTool);
+    placeToolOnCanvas(registered);
+
+    // Add to sidebar list so the user can stamp more copies
+    generatedToolsList.push(registered);
+    // Trigger Zwibbler digest so z-for picks up the new entry
+    zwibblerCtx.generatedTools = generatedToolsList.concat();
+    if (zwibblerCtx.$digest) zwibblerCtx.$digest();
+
+    window.closeGenerator();
+  };
+
+  // ── Zwibbler Component Registration ──────────────────────
+
+  /**
+   * Register the generated tool as a Zwibbler component and return
+   * metadata that allows placing it on the canvas later.
+   */
+  function registerZwibblerComponent(tool) {
+    generatedToolCounter++;
+    const componentName = `GeneratedTool_${generatedToolCounter}`;
+    const fullHTML = Sandbox.buildComponentHTML(tool);
+
+    Zwibbler.component(componentName, {
+      template: `
+        <div class="widget-root" z-sizeable="stretch"
+             style="width:${tool.width}px; height:${tool.height}px; overflow:auto; background:#fff; border-radius:6px; box-shadow:0 2px 8px rgba(0,0,0,0.15);">
+          ${fullHTML}
+        </div>
+      `,
+      controller(scope) {
+        // scope.$element is the root DOM element of the component
+        const el = scope.$element;
+        if (!el) return;
+        const root = el.querySelector(".widget-root");
+        if (!root) return;
+
+        // Run the generated JS in a try/catch so a widget bug doesn't crash the whiteboard
+        try {
+          const fn = new Function("scope", "el", tool.js);
+          fn(scope, root);
+        } catch (err) {
+          console.error(`[${componentName}] Widget JS error:`, err);
+          root.textContent = `Widget error: ${err.message}`;
+          root.style.cssText += "color:red; padding:20px; font-size:14px;";
+        }
+      },
+    });
+
+    return {
+      componentName,
+      label: tool.label,
+      description: tool.description,
+      width: tool.width,
+      height: tool.height,
+    };
+  }
+
+  /**
+   * Place a registered tool component onto the Zwibbler canvas.
+   */
+  function placeToolOnCanvas(toolMeta) {
+    if (!zwibblerCtx) return;
+    zwibblerCtx.begin();
+    zwibblerCtx.createHTMLNode(toolMeta.componentName, {
+      "style.width": toolMeta.width + "px",
+      "style.height": toolMeta.height + "px",
+    });
+    zwibblerCtx.commit();
+  }
+
+})();

--- a/zwibbler-tool-generator/index.html
+++ b/zwibbler-tool-generator/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Zwibbler Tool Generator</title>
+  <link rel="stylesheet" href="style.css">
+  <!-- Zwibbler must be loaded from your licensed copy -->
+  <script src="zwibbler.js"></script>
+</head>
+<body>
+
+<div id="app">
+  <div zwibbler z-controller="initApp">
+
+    <!-- Top bar -->
+    <header id="top-bar">
+      <h1>Zwibbler + AI Tool Generator</h1>
+      <div id="top-actions">
+        <button z-click="undo()" z-disabled="!canUndo()">Undo</button>
+        <button z-click="redo()" z-disabled="!canRedo()">Redo</button>
+        <button z-click="zoomIn()">Zoom +</button>
+        <button z-click="zoomOut()">Zoom &minus;</button>
+      </div>
+    </header>
+
+    <div id="main-layout">
+
+      <!-- Left toolbar -->
+      <aside id="toolbar">
+        <div class="tool-section">
+          <h3>Drawing</h3>
+          <button z-click="usePickTool()" z-class="{'active': getCurrentTool()==='pick'}">Select</button>
+          <button z-click="useBrushTool()" z-class="{'active': getCurrentTool()==='brush'}">Pen</button>
+          <button z-click="useLineTool()" z-class="{'active': getCurrentTool()==='line'}">Line</button>
+          <button z-click="useRectangleTool()" z-class="{'active': getCurrentTool()==='rectangle'}">Rectangle</button>
+          <button z-click="useCircleTool()" z-class="{'active': getCurrentTool()==='circle'}">Circle</button>
+          <button z-click="useTextTool()" z-class="{'active': getCurrentTool()==='text'}">Text</button>
+        </div>
+
+        <div class="tool-section">
+          <h3>AI Tools</h3>
+          <button id="btn-generate" z-click="openGenerator()">+ Generate Tool</button>
+          <div id="generated-tools-list" z-for="tool in generatedTools">
+            <button
+              class="generated-tool-btn"
+              z-click="placeGeneratedTool(tool)"
+              z-text="tool.label"
+            ></button>
+          </div>
+        </div>
+      </aside>
+
+      <!-- Canvas -->
+      <div id="canvas-area">
+        <div z-canvas></div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<!-- Tool Generator Dialog -->
+<div id="generator-overlay" class="overlay hidden">
+  <div id="generator-dialog">
+    <div id="generator-header">
+      <h2>Generate an Academic Tool</h2>
+      <button id="generator-close" onclick="closeGenerator()">&times;</button>
+    </div>
+
+    <div id="generator-body">
+      <label for="tool-prompt">Describe the tool you need:</label>
+      <textarea
+        id="tool-prompt"
+        rows="4"
+        placeholder="e.g., A simple calculator with basic arithmetic, a periodic table of elements, a unit converter for physics, an interactive number line..."
+      ></textarea>
+
+      <div id="category-hints">
+        <span class="hint-chip" onclick="setPromptHint(this)">Calculator</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Graph paper</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Periodic table</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Unit converter</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Number line</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Multiplication table</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Fraction visualizer</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Protractor</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Coordinate plane</span>
+        <span class="hint-chip" onclick="setPromptHint(this)">Timer / Stopwatch</span>
+      </div>
+
+      <div id="generator-options">
+        <label>
+          <span>Size:</span>
+          <select id="tool-size">
+            <option value="small">Small (300x200)</option>
+            <option value="medium" selected>Medium (450x350)</option>
+            <option value="large">Large (600x500)</option>
+          </select>
+        </label>
+      </div>
+
+      <button id="btn-do-generate" onclick="doGenerate()">Generate Tool</button>
+
+      <div id="generator-status" class="hidden">
+        <div class="spinner"></div>
+        <span id="status-text">Generating your tool...</span>
+      </div>
+
+      <div id="generator-preview" class="hidden">
+        <h3>Preview</h3>
+        <div id="preview-frame-wrapper">
+          <iframe id="preview-frame" sandbox="allow-scripts"></iframe>
+        </div>
+        <div id="preview-actions">
+          <button onclick="acceptTool()">Place on Canvas</button>
+          <button onclick="regenerateTool()">Regenerate</button>
+          <button onclick="closeGenerator()">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="tool-generator.js"></script>
+<script src="sandbox.js"></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/zwibbler-tool-generator/sandbox.js
+++ b/zwibbler-tool-generator/sandbox.js
@@ -1,0 +1,163 @@
+/**
+ * sandbox.js
+ *
+ * Validates and sanitizes AI-generated widget code before it is registered
+ * as a Zwibbler component. This is the safety layer between the AI output
+ * and the whiteboard runtime.
+ *
+ * Defence in depth:
+ *   1. Static analysis — reject code containing dangerous patterns
+ *   2. CSP via sandboxed iframe for preview (allow-scripts only, no same-origin)
+ *   3. Runtime wrapper — the JS runs inside a controller where globals are limited
+ *   4. Zwibbler's own HTML node sandboxing (components run in the page but are
+ *      scoped to their element)
+ */
+
+const Sandbox = (() => {
+
+  // ── Blocklists ───────────────────────────────────────────
+  //
+  // Each entry is [regex, human-readable reason].
+  // We check both the JS and HTML for these patterns.
+
+  const BLOCKED_PATTERNS = [
+    // Network access
+    [/\bfetch\s*\(/i,                         "Network requests (fetch) are not allowed"],
+    [/\bXMLHttpRequest\b/i,                   "Network requests (XMLHttpRequest) are not allowed"],
+    [/\bWebSocket\b/i,                        "WebSocket connections are not allowed"],
+    [/\bEventSource\b/i,                      "Server-sent events are not allowed"],
+    [/\bnavigator\.sendBeacon\b/i,            "navigator.sendBeacon is not allowed"],
+    [/\bimportScripts\b/i,                    "importScripts is not allowed"],
+
+    // Dynamic code execution
+    [/\beval\s*\(/i,                          "eval() is not allowed"],
+    [/\bnew\s+Function\s*\(/i,               "new Function() is not allowed"],
+    [/\bsetTimeout\s*\(\s*["`']/i,           "setTimeout with string argument is not allowed"],
+    [/\bsetInterval\s*\(\s*["`']/i,          "setInterval with string argument is not allowed"],
+
+    // DOM escape / injection
+    [/\bdocument\s*\.\s*write/i,             "document.write is not allowed"],
+    [/\bdocument\s*\.\s*cookie/i,            "document.cookie access is not allowed"],
+    [/\bdocument\b[^.]*\.innerHTML\s*=/i,     "document innerHTML assignment is not allowed"],
+    [/\.outerHTML\s*=/i,                      "outerHTML assignment is not allowed"],
+    [/\bdocument\.createElement\s*\(\s*['"`]script/i,  "Creating <script> elements is not allowed"],
+    [/\bdocument\.createElement\s*\(\s*['"`]iframe/i,  "Creating <iframe> elements is not allowed"],
+    [/\bdocument\.createElement\s*\(\s*['"`]object/i,  "Creating <object> elements is not allowed"],
+    [/\bdocument\.createElement\s*\(\s*['"`]embed/i,   "Creating <embed> elements is not allowed"],
+    [/\bdocument\.createElement\s*\(\s*['"`]link/i,    "Creating <link> elements is not allowed"],
+
+    // Storage
+    [/\blocalStorage\b/i,                     "localStorage is not allowed"],
+    [/\bsessionStorage\b/i,                   "sessionStorage is not allowed"],
+    [/\bindexedDB\b/i,                        "indexedDB is not allowed"],
+
+    // Navigation
+    [/\bwindow\s*\.\s*open\s*\(/i,           "window.open is not allowed"],
+    [/\bwindow\s*\.\s*location/i,            "window.location access is not allowed"],
+    [/\blocation\s*\.\s*href/i,              "location.href is not allowed"],
+    [/\blocation\s*\.\s*assign/i,            "location.assign is not allowed"],
+    [/\blocation\s*\.\s*replace\s*\(/i,      "location.replace is not allowed"],
+
+    // External resources
+    [/https?:\/\//i,                          "External URLs are not allowed"],
+    [/\bimport\s*\(/i,                        "Dynamic import() is not allowed"],
+    [/\bimport\s+/i,                          "ES module imports are not allowed"],
+    [/\brequire\s*\(/i,                       "require() is not allowed"],
+  ];
+
+  // Additional patterns only checked in HTML
+  const BLOCKED_HTML_PATTERNS = [
+    [/<script[\s>]/i,                         "<script> tags are not allowed"],
+    [/<iframe[\s>]/i,                         "<iframe> tags are not allowed"],
+    [/<object[\s>]/i,                         "<object> tags are not allowed"],
+    [/<embed[\s>]/i,                          "<embed> tags are not allowed"],
+    [/<link[\s>]/i,                           "<link> tags are not allowed"],
+    [/\bon(?:click|load|error|mouse\w+|key\w+|focus|blur|change|submit|input|dblclick|contextmenu|drag\w*|drop|scroll|wheel|touch\w+|pointer\w+|animationend|transitionend)\s*=/i, "Inline event handlers are not allowed"],
+    [/javascript\s*:/i,                       "javascript: URLs are not allowed"],
+    [/=\s*["']data\s*:/i,                     "data: URLs are not allowed in HTML attributes"],
+  ];
+
+  // ── Validation ───────────────────────────────────────────
+
+  /**
+   * Validate a generated tool definition.
+   * Returns { valid: true } or { valid: false, reasons: string[] }.
+   */
+  function validate(tool) {
+    const reasons = [];
+
+    // Check JS
+    for (const [pattern, reason] of BLOCKED_PATTERNS) {
+      if (pattern.test(tool.js)) {
+        reasons.push(`[JS] ${reason}`);
+      }
+    }
+
+    // Check HTML
+    for (const [pattern, reason] of [...BLOCKED_PATTERNS, ...BLOCKED_HTML_PATTERNS]) {
+      if (pattern.test(tool.html)) {
+        reasons.push(`[HTML] ${reason}`);
+      }
+    }
+
+    // Check CSS (mainly for url() references to external resources)
+    if (/url\s*\(/i.test(tool.css)) {
+      reasons.push("[CSS] url() references are not allowed");
+    }
+
+    if (reasons.length > 0) {
+      return { valid: false, reasons };
+    }
+    return { valid: true };
+  }
+
+  // ── Component HTML builder ──────────────────────────────
+  //
+  // Combines CSS + HTML for Zwibbler component registration.
+
+  /**
+   * Build the full HTML string for a widget, combining its CSS and HTML.
+   * This is used once during component registration — not at runtime.
+   */
+  function buildComponentHTML(tool) {
+    return `<style>${tool.css}</style>${tool.html}`;
+  }
+
+  // ── Preview in sandboxed iframe ──────────────────────────
+
+  /**
+   * Render a tool inside a sandboxed iframe for preview purposes.
+   * The iframe uses srcdoc with sandbox="allow-scripts" (no same-origin).
+   */
+  function renderPreview(iframeEl, tool) {
+    const doc = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, -apple-system, sans-serif; padding: 12px; }
+  ${tool.css}
+</style>
+</head>
+<body>
+${tool.html}
+<script>
+(function() {
+  var el = document.querySelector('.widget-root');
+  if (!el) return;
+  ${tool.js}
+})();
+<\/script>
+</body>
+</html>`;
+
+    iframeEl.removeAttribute("src");
+    iframeEl.srcdoc = doc;
+  }
+
+  // ── Public API ───────────────────────────────────────────
+
+  return { validate, buildComponentHTML, renderPreview };
+
+})();

--- a/zwibbler-tool-generator/server.js
+++ b/zwibbler-tool-generator/server.js
@@ -1,0 +1,223 @@
+/**
+ * server.js
+ *
+ * Lightweight dev server that:
+ *   1. Serves the static frontend files
+ *   2. Proxies /api/generate requests to the Anthropic API
+ *      (avoids CORS issues with direct browser → Anthropic calls)
+ *
+ * Usage:
+ *   ANTHROPIC_API_KEY=sk-... node server.js
+ *
+ * The server reads the API key from the environment so it never touches
+ * the browser. Runs on port 3000 by default (PORT env to override).
+ */
+
+const http = require("http");
+const fs   = require("fs");
+const path = require("path");
+const url  = require("url");
+
+const PORT    = parseInt(process.env.PORT, 10) || 3000;
+const API_KEY = process.env.ANTHROPIC_API_KEY || "";
+
+if (!API_KEY) {
+  console.warn(
+    "WARNING: ANTHROPIC_API_KEY not set.\n" +
+    "The /api/generate endpoint will fail. You can still use the frontend\n" +
+    "with a client-side key, but the proxy route won't work.\n"
+  );
+}
+
+// ── MIME types ───────────────────────────────────────────
+
+const MIME = {
+  ".html": "text/html",
+  ".css":  "text/css",
+  ".js":   "application/javascript",
+  ".json": "application/json",
+  ".png":  "image/png",
+  ".svg":  "image/svg+xml",
+};
+
+// ── Static file serving ─────────────────────────────────
+
+function serveStatic(req, res) {
+  let filePath = path.join(__dirname, url.parse(req.url).pathname);
+
+  // Default to index.html
+  if (filePath.endsWith("/")) filePath += "index.html";
+
+  const ext = path.extname(filePath);
+  const contentType = MIME[ext] || "application/octet-stream";
+
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+      return;
+    }
+    res.writeHead(200, { "Content-Type": contentType });
+    res.end(data);
+  });
+}
+
+// ── API proxy ───────────────────────────────────────────
+
+async function handleApiGenerate(req, res) {
+  if (req.method !== "POST") {
+    res.writeHead(405, { "Content-Type": "text/plain" });
+    res.end("Method not allowed");
+    return;
+  }
+
+  if (!API_KEY) {
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Server has no ANTHROPIC_API_KEY configured" }));
+    return;
+  }
+
+  // Read request body
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const body = Buffer.concat(chunks).toString();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Invalid JSON body" }));
+    return;
+  }
+
+  const { prompt, size } = parsed;
+  if (!prompt || typeof prompt !== "string") {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Missing 'prompt' field" }));
+    return;
+  }
+
+  try {
+    // We dynamically build the same request that ToolGenerator builds client-side,
+    // but here we attach the server-side API key.
+    const anthropicRes = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5-20250929",
+        max_tokens: 4096,
+        system: getSystemPrompt(),
+        messages: [{
+          role: "user",
+          content: buildUserMessage(prompt, size),
+        }],
+      }),
+    });
+
+    const anthropicBody = await anthropicRes.text();
+
+    res.writeHead(anthropicRes.status, {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.end(anthropicBody);
+  } catch (err) {
+    console.error("Anthropic API error:", err);
+    res.writeHead(502, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Failed to reach Anthropic API" }));
+  }
+}
+
+function getSystemPrompt() {
+  // Same system prompt as tool-generator.js — duplicated here so the server
+  // can operate independently if the client sends raw prompts.
+  return `You are an expert frontend developer who creates self-contained HTML widgets for an academic whiteboard application powered by Zwibbler.
+
+## Your Task
+Generate a SINGLE self-contained HTML widget based on the user's description. The widget will be embedded inside a Zwibbler whiteboard as an interactive HTML component.
+
+## Output Format
+Return ONLY a JSON object with this exact structure — no markdown fences, no explanation:
+{
+  "label": "Short Name (2-4 words)",
+  "description": "One sentence describing what this tool does",
+  "html": "<div class=\\"widget-root\\">...the full HTML...</div>",
+  "css": "/* scoped CSS for .widget-root and descendants */",
+  "js": "// JS that runs inside controller(scope, el) where el is the root element"
+}
+
+## Constraints — you MUST follow ALL of these:
+
+### Safety
+- NO fetch, XMLHttpRequest, WebSocket, EventSource, or any network requests
+- NO eval, Function(), setTimeout with strings, or dynamic code execution
+- NO document.cookie, localStorage, sessionStorage, indexedDB access
+- NO window.open, window.location, or navigation
+- NO creating <script>, <link>, <iframe>, <object>, <embed> elements
+- NO inline event handlers in HTML (onclick="..." etc.) — use addEventListener in the JS section
+- NO importing or loading external libraries, fonts, images, or resources of any kind
+- ALL functionality must be implemented from scratch using only vanilla JS, HTML, and CSS
+- NO references to external URLs whatsoever
+- You MAY use element.innerHTML on elements within the widget for dynamic content. Do NOT use document.innerHTML or document.body.innerHTML.
+- Prefer textContent over innerHTML when displaying plain text (for safety)
+
+### Structure
+- The "html" value must be a single root <div class="widget-root"> containing all markup
+- The "css" value must scope everything under .widget-root to avoid style leaks
+- The "js" value is a function body that receives (scope, el) — "el" is the root DOM element. Use el.querySelector/querySelectorAll to find elements. Do NOT use document.querySelector.
+- Use data attributes or classes to identify elements — not IDs (multiple instances may coexist)
+- The widget must work at the specified dimensions and handle resize gracefully
+
+### Academic Focus
+- Tools must serve a clear educational or academic purpose
+- Content must be accurate (correct formulas, correct data, correct conversions)
+- Design should be clean, readable, and classroom-appropriate
+- Use clear labels, legible fonts (system fonts only), and good contrast
+
+### Quality
+- Make the widget genuinely useful and interactive, not just a static display
+- Handle edge cases (division by zero, empty inputs, out-of-range values)
+- Use semantic HTML where appropriate
+- Ensure the widget looks polished — use consistent spacing, alignment, colors`;
+}
+
+function buildUserMessage(prompt, size) {
+  const SIZES = { small: [300, 200], medium: [450, 350], large: [600, 500] };
+  const [w, h] = SIZES[size] || SIZES.medium;
+  return `Create a widget for: ${prompt}\n\nTarget dimensions: ${w}px wide by ${h}px tall.\n\nRemember: return ONLY the JSON object, no markdown fencing or extra text.`;
+}
+
+// ── Request router ──────────────────────────────────────
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url);
+
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+    res.end();
+    return;
+  }
+
+  if (parsed.pathname === "/api/generate") {
+    handleApiGenerate(req, res);
+  } else {
+    serveStatic(req, res);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`\n  Zwibbler Tool Generator`);
+  console.log(`  ───────────────────────`);
+  console.log(`  http://localhost:${PORT}\n`);
+  console.log(`  API key: ${API_KEY ? "configured (server-side proxy active)" : "NOT SET (client-side mode only)"}\n`);
+});

--- a/zwibbler-tool-generator/style.css
+++ b/zwibbler-tool-generator/style.css
@@ -1,0 +1,140 @@
+/* ── Reset & Base ─────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg:        #1a1a2e;
+  --surface:   #16213e;
+  --surface2:  #0f3460;
+  --accent:    #e94560;
+  --accent2:   #533483;
+  --text:      #eee;
+  --text-dim:  #aaa;
+  --radius:    6px;
+}
+
+html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; background: var(--bg); color: var(--text); }
+
+#app { height: 100%; display: flex; flex-direction: column; }
+#app > [zwibbler] { display: flex; flex-direction: column; height: 100%; }
+
+/* ── Top bar ─────────────────────────────────────────────── */
+#top-bar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 16px; background: var(--surface); border-bottom: 1px solid var(--surface2);
+}
+#top-bar h1 { font-size: 16px; font-weight: 600; }
+#top-actions { display: flex; gap: 6px; }
+#top-actions button {
+  padding: 4px 10px; border: 1px solid var(--surface2); border-radius: var(--radius);
+  background: var(--surface2); color: var(--text); cursor: pointer; font-size: 13px;
+}
+#top-actions button:disabled { opacity: 0.4; cursor: default; }
+#top-actions button:hover:not(:disabled) { background: var(--accent2); }
+
+/* ── Main layout ─────────────────────────────────────────── */
+#main-layout { display: flex; flex: 1; min-height: 0; }
+
+/* ── Left toolbar ────────────────────────────────────────── */
+#toolbar {
+  width: 170px; flex-shrink: 0; padding: 12px;
+  background: var(--surface); border-right: 1px solid var(--surface2);
+  overflow-y: auto; display: flex; flex-direction: column; gap: 16px;
+}
+.tool-section h3 { font-size: 11px; text-transform: uppercase; color: var(--text-dim); margin-bottom: 6px; letter-spacing: 0.5px; }
+.tool-section button {
+  display: block; width: 100%; padding: 7px 10px; margin-bottom: 4px;
+  border: 1px solid transparent; border-radius: var(--radius);
+  background: transparent; color: var(--text); cursor: pointer;
+  text-align: left; font-size: 13px; transition: background 0.15s;
+}
+.tool-section button:hover { background: var(--surface2); }
+.tool-section button.active { background: var(--accent2); border-color: var(--accent); }
+
+#btn-generate {
+  background: var(--accent) !important; color: #fff !important;
+  font-weight: 600; border: none !important; text-align: center !important;
+}
+#btn-generate:hover { filter: brightness(1.15); }
+
+.generated-tool-btn { font-size: 12px !important; }
+
+/* ── Canvas ──────────────────────────────────────────────── */
+#canvas-area { flex: 1; position: relative; background: #fff; }
+#canvas-area [z-canvas] { width: 100%; height: 100%; }
+
+/* ── Overlay / Dialog ────────────────────────────────────── */
+.overlay {
+  position: fixed; inset: 0; z-index: 9000;
+  background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center;
+}
+.overlay.hidden { display: none; }
+
+#generator-dialog {
+  width: 560px; max-height: 90vh; overflow-y: auto;
+  background: var(--surface); border: 1px solid var(--surface2);
+  border-radius: 10px; box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+}
+#generator-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 16px 20px; border-bottom: 1px solid var(--surface2);
+}
+#generator-header h2 { font-size: 18px; }
+#generator-close {
+  background: none; border: none; color: var(--text-dim); font-size: 24px; cursor: pointer; line-height: 1;
+}
+#generator-body { padding: 20px; }
+#generator-body label { display: block; font-size: 14px; margin-bottom: 6px; color: var(--text-dim); }
+
+#tool-prompt {
+  width: 100%; padding: 10px; border: 1px solid var(--surface2); border-radius: var(--radius);
+  background: var(--bg); color: var(--text); font-size: 14px; resize: vertical; font-family: inherit;
+}
+#tool-prompt:focus { outline: none; border-color: var(--accent); }
+
+#category-hints { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0 16px; }
+.hint-chip {
+  padding: 4px 10px; border-radius: 20px; font-size: 12px;
+  background: var(--surface2); color: var(--text-dim); cursor: pointer; transition: background 0.15s;
+}
+.hint-chip:hover { background: var(--accent2); color: var(--text); }
+
+#generator-options { margin-bottom: 16px; }
+#generator-options label { display: flex; align-items: center; gap: 8px; }
+#generator-options select {
+  padding: 4px 8px; border: 1px solid var(--surface2); border-radius: var(--radius);
+  background: var(--bg); color: var(--text); font-size: 13px;
+}
+
+#btn-do-generate {
+  width: 100%; padding: 10px; border: none; border-radius: var(--radius);
+  background: var(--accent); color: #fff; font-size: 15px; font-weight: 600; cursor: pointer;
+  transition: filter 0.15s;
+}
+#btn-do-generate:hover { filter: brightness(1.15); }
+#btn-do-generate:disabled { opacity: 0.5; cursor: default; filter: none; }
+
+/* ── Status / spinner ────────────────────────────────────── */
+#generator-status { display: flex; align-items: center; gap: 10px; margin-top: 16px; }
+#generator-status.hidden { display: none; }
+.spinner {
+  width: 20px; height: 20px; border: 3px solid var(--surface2); border-top-color: var(--accent);
+  border-radius: 50%; animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Preview ─────────────────────────────────────────────── */
+#generator-preview { margin-top: 20px; }
+#generator-preview.hidden { display: none; }
+#generator-preview h3 { font-size: 14px; margin-bottom: 8px; }
+#preview-frame-wrapper {
+  border: 1px solid var(--surface2); border-radius: var(--radius);
+  overflow: hidden; background: #fff;
+}
+#preview-frame { width: 100%; height: 350px; border: none; }
+#preview-actions { display: flex; gap: 8px; margin-top: 10px; }
+#preview-actions button {
+  flex: 1; padding: 8px; border: 1px solid var(--surface2); border-radius: var(--radius);
+  background: var(--surface2); color: var(--text); font-size: 13px; cursor: pointer;
+}
+#preview-actions button:first-child { background: var(--accent); border-color: var(--accent); font-weight: 600; }
+#preview-actions button:hover { filter: brightness(1.15); }

--- a/zwibbler-tool-generator/tool-generator.js
+++ b/zwibbler-tool-generator/tool-generator.js
@@ -1,0 +1,175 @@
+/**
+ * tool-generator.js
+ *
+ * Calls the Claude API to generate self-contained HTML/CSS/JS widgets
+ * that can be registered as Zwibbler components and placed on the canvas.
+ *
+ * The generation uses a structured system prompt that constrains output to
+ * safe, academic-context HTML widgets — no external network requests, no
+ * arbitrary code execution, no dangerous APIs.
+ */
+
+const ToolGenerator = (() => {
+
+  // ── Configuration ────────────────────────────────────────
+
+  const SIZES = {
+    small:  { width: 300, height: 200 },
+    medium: { width: 450, height: 350 },
+    large:  { width: 600, height: 500 },
+  };
+
+  // ── System prompt ────────────────────────────────────────
+  //
+  // This is the core of the generation strategy. It constrains Claude to
+  // produce a Zwibbler-compatible HTML component that is:
+  //   - self-contained (inline CSS & JS, no external resources)
+  //   - safe (no fetch, no eval, no dynamic script injection)
+  //   - academic in purpose
+  //   - well-structured for Zwibbler's component system
+
+  const SYSTEM_PROMPT = `You are an expert frontend developer who creates self-contained HTML widgets for an academic whiteboard application powered by Zwibbler.
+
+## Your Task
+Generate a SINGLE self-contained HTML widget based on the user's description. The widget will be embedded inside a Zwibbler whiteboard as an interactive HTML component.
+
+## Output Format
+Return ONLY a JSON object with this exact structure — no markdown fences, no explanation:
+{
+  "label": "Short Name (2-4 words)",
+  "description": "One sentence describing what this tool does",
+  "html": "<div class=\\"widget-root\\">...the full HTML...</div>",
+  "css": "/* scoped CSS for .widget-root and descendants */",
+  "js": "// JS that runs inside controller(scope, el) where el is the root element"
+}
+
+## Constraints — you MUST follow ALL of these:
+
+### Safety
+- NO fetch, XMLHttpRequest, WebSocket, EventSource, or any network requests
+- NO eval, Function(), setTimeout with strings, or dynamic code execution
+- NO document.cookie, localStorage, sessionStorage, indexedDB access
+- NO window.open, window.location, or navigation
+- NO creating <script>, <link>, <iframe>, <object>, <embed> elements
+- NO inline event handlers in HTML (onclick="..." etc.) — use addEventListener in the JS section
+- NO importing or loading external libraries, fonts, images, or resources of any kind
+- ALL functionality must be implemented from scratch using only vanilla JS, HTML, and CSS
+- NO references to external URLs whatsoever
+- You MAY use element.innerHTML on elements within the widget for dynamic content. Do NOT use document.innerHTML or document.body.innerHTML.
+- Prefer textContent over innerHTML when displaying plain text (for safety)
+
+### Structure
+- The "html" value must be a single root <div class="widget-root"> containing all markup
+- The "css" value must scope everything under .widget-root to avoid style leaks
+- The "js" value is a function body that receives (scope, el) — "el" is the root DOM element. Use el.querySelector/querySelectorAll to find elements. Do NOT use document.querySelector.
+- Use data attributes or classes to identify elements — not IDs (multiple instances may coexist)
+- The widget must work at the specified dimensions and handle resize gracefully
+
+### Academic Focus
+- Tools must serve a clear educational or academic purpose
+- Content must be accurate (correct formulas, correct data, correct conversions)
+- Design should be clean, readable, and classroom-appropriate
+- Use clear labels, legible fonts (system fonts only), and good contrast
+
+### Quality
+- Make the widget genuinely useful and interactive, not just a static display
+- Handle edge cases (division by zero, empty inputs, out-of-range values)
+- Use semantic HTML where appropriate
+- Ensure the widget looks polished — use consistent spacing, alignment, colors`;
+
+  // ── Generation ───────────────────────────────────────────
+
+  /**
+   * Generate a tool widget via the Claude API.
+   *
+   * Supports two modes:
+   *   1. Server proxy (preferred): POST to /api/generate — API key lives server-side
+   *   2. Direct browser call: sends key with anthropic-dangerous-direct-browser-access
+   *
+   * @param {string} apiKey   - Anthropic API key (empty string = use server proxy)
+   * @param {string} prompt   - User's description of the tool they want
+   * @param {string} sizeKey  - "small" | "medium" | "large"
+   * @returns {Promise<object>} - { label, description, html, css, js, width, height }
+   */
+  async function generate(apiKey, prompt, sizeKey = "medium") {
+    const size = SIZES[sizeKey] || SIZES.medium;
+
+    let data;
+
+    if (!apiKey) {
+      // Mode 1: server-side proxy — key is in env on the server
+      const response = await fetch("/api/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt, size: sizeKey }),
+      });
+      if (!response.ok) {
+        const err = await response.text();
+        throw new Error(`Server proxy error (${response.status}): ${err}`);
+      }
+      data = await response.json();
+    } else {
+      // Mode 2: direct browser → Anthropic API
+      const userMessage = `Create a widget for: ${prompt}\n\nTarget dimensions: ${size.width}px wide by ${size.height}px tall.\n\nRemember: return ONLY the JSON object, no markdown fencing or extra text.`;
+
+      const response = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+          "anthropic-dangerous-direct-browser-access": "true",
+        },
+        body: JSON.stringify({
+          model: "claude-sonnet-4-5-20250929",
+          max_tokens: 4096,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: "user", content: userMessage }],
+        }),
+      });
+
+      if (!response.ok) {
+        const err = await response.text();
+        throw new Error(`API request failed (${response.status}): ${err}`);
+      }
+      data = await response.json();
+    }
+
+    const text = data.content[0].text.trim();
+
+    // Parse the JSON response — strip markdown fences if the model included them despite instructions
+    let cleaned = text;
+    if (cleaned.startsWith("```")) {
+      cleaned = cleaned.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "");
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch (e) {
+      throw new Error("Failed to parse generated tool JSON. The model returned invalid output.");
+    }
+
+    // Validate required fields
+    for (const field of ["label", "html", "css", "js"]) {
+      if (typeof parsed[field] !== "string") {
+        throw new Error(`Generated tool is missing required field: "${field}"`);
+      }
+    }
+
+    return {
+      label: parsed.label,
+      description: parsed.description || "",
+      html: parsed.html,
+      css: parsed.css,
+      js: parsed.js,
+      width: size.width,
+      height: size.height,
+    };
+  }
+
+  // ── Public API ───────────────────────────────────────────
+
+  return { generate, SIZES };
+
+})();


### PR DESCRIPTION
Users describe academic tools in natural language (calculator, periodic
table, unit converter, etc.) and a Claude-backed agent generates
interactive HTML widgets that drop directly onto the Zwibbler canvas.

Architecture:
- tool-generator.js: Claude API integration with constrained system prompt
- sandbox.js: static analysis validator blocking ~30 dangerous patterns
  (network, eval, navigation, storage, external resources)
- app.js: Zwibbler controller, component registration via
  Zwibbler.component() + createHTMLNode(), dialog lifecycle
- server.js: optional Node dev server with API proxy to keep key server-side
- Sandboxed iframe preview before accepting generated widgets

https://claude.ai/code/session_01X2A22TQSvpYzMF6CWrZK2M